### PR TITLE
fix: decline join request when verification photo fails to send

### DIFF
--- a/src/plugins/gatekeeper/request_verify_handle.go
+++ b/src/plugins/gatekeeper/request_verify_handle.go
@@ -63,8 +63,8 @@ func VerifyRequestMember(update tgbotapi.Update) {
 	sendPhoto.Caption = "请选择上图干员的正确名字"
 	photo, err := bot.Arknights.Send(sendPhoto)
 	if err != nil {
-		log.Printf("发送图片失败：%s，原因：%s", correct.ThumbURL, err.Error())
-		bot.Arknights.ApproveChatJoinRequest(chatId, userId)
+		log.Printf("发送验证图片失败，拒绝入群申请。用户：%d，群：%d，图片：%s，原因：%s", userId, chatId, correct.ThumbURL, err.Error())
+		bot.Arknights.DeclineChatJoinRequest(chatId, userId)
 		verifySet.checkExistAndRemove(userId, chatId)
 		return
 	}


### PR DESCRIPTION
入群申请审核中，若向申请人发送验证图片失败（常见于申请人从未私聊过机器人、拉黑机器人、图片源不可用或瞬时 API 错误），当前代码会直接调用 ApproveChatJoinRequest 放行，SPAM 账号无需答题即可入群。

本 PR 将失败路径改为拒绝入群（DeclineChatJoinRequest），与 60 秒超时拒绝逻辑保持一致（fail-closed）。