### PR TITLE
fix: store per-user verification answers, fix key collision

### DIFF
--- a/src/plugins/gatekeeper/safe_verify_set.go
+++ b/src/plugins/gatekeeper/safe_verify_set.go
@@ -7,44 +7,40 @@ import (
 
 type chatidT = int64
 type useridT = int64
+
+// safeCallBack 记录每个群内待验证用户的正确答案
 type safeCallBack struct {
-	mu      sync.Mutex
-	set     map[string]bool
-	correct string
+	mu  sync.Mutex
+	set map[string]string
 }
 
-var verifySet = safeCallBack{set: make(map[string]bool)}
+var verifySet = safeCallBack{set: make(map[string]string)}
 
 func (b *safeCallBack) add(userId useridT, chatId chatidT, correct string) {
 	b.mu.Lock()
-	val := fmt.Sprintf("%d%d", chatId, userId)
-	b.set[val] = true
-	b.correct = correct
-	b.mu.Unlock()
+	defer b.mu.Unlock()
+	b.set[verifyKey(chatId, userId)] = correct
 }
 
 func (b *safeCallBack) checkExist(userId useridT, chatId chatidT) bool {
-	defer b.mu.Unlock()
 	b.mu.Lock()
-	val := fmt.Sprintf("%d%d", chatId, userId)
-	if b._checkVal(val) {
-		return true
-	}
-	return false
+	defer b.mu.Unlock()
+	_, ok := b.set[verifyKey(chatId, userId)]
+	return ok
 }
 
 func (b *safeCallBack) checkExistAndRemove(userId useridT, chatId chatidT) (bool, string) {
-	defer b.mu.Unlock()
 	b.mu.Lock()
-	val := fmt.Sprintf("%d%d", chatId, userId)
-	if b._checkVal(val) {
-		delete(b.set, val)
-		return true, b.correct
+	defer b.mu.Unlock()
+	key := verifyKey(chatId, userId)
+	if correct, ok := b.set[key]; ok {
+		delete(b.set, key)
+		return true, correct
 	}
 	return false, ""
 }
 
-func (b *safeCallBack) _checkVal(val string) bool {
-	_, ok := b.set[val]
-	return ok
+// verifyKey 使用分隔符拼接 (chatId, userId)，避免如 (12,345) 与 (123,45) 产生相同 key
+func verifyKey(chatId chatidT, userId useridT) string {
+	return fmt.Sprintf("%d:%d", chatId, userId)
 }


### PR DESCRIPTION
verifySet 的 correct 字段是全局共享变量，多个用户/多个群并发验证时会互相覆盖：用户 A 申请后用户 B 再申请，A 点正确答案也会被判定为错误而拒绝；群内验证模式还会把全局答案置空串。此外 set 的 key 用 %d%d 直接拼接，存在 (chatId, userId) 组合碰撞。

本 PR 将正确答案改为按 (chatId, userId) 独立存储，key 增加分隔符，消除跨用户误判与 key 碰撞。