### PR TITLE
fix: block users after repeated wrong answers (anti brute-force)

### DIFF
--- a/src/plugins/gatekeeper/attempt_limiter.go
+++ b/src/plugins/gatekeeper/attempt_limiter.go
@@ -1,0 +1,68 @@
+package gatekeeper
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	// maxFailAttempts 连续答错次数上限，超过后限制再次申请入群
+	maxFailAttempts = 3
+	// blockDuration 超过答错上限后的封禁时长
+	blockDuration = 24 * time.Hour
+)
+
+// attemptLimiter 记录入群申请答题失败次数，防止通过反复申请穷举答案
+type attemptLimiter struct {
+	mu      sync.Mutex
+	fails   map[string]int
+	blocked map[string]time.Time
+}
+
+var limiter = attemptLimiter{
+	fails:   make(map[string]int),
+	blocked: make(map[string]time.Time),
+}
+
+// recordFail 记录一次答题失败，达到上限后进入封禁状态，返回累计失败次数
+func (l *attemptLimiter) recordFail(chatId int64, userId int64) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	key := limiterKey(chatId, userId)
+	l.fails[key]++
+	if l.fails[key] >= maxFailAttempts {
+		l.blocked[key] = time.Now().Add(blockDuration)
+	}
+	return l.fails[key]
+}
+
+// resetFail 答题通过后清零失败记录与封禁状态
+func (l *attemptLimiter) resetFail(chatId int64, userId int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	key := limiterKey(chatId, userId)
+	delete(l.fails, key)
+	delete(l.blocked, key)
+}
+
+// isBlocked 判断用户是否处于封禁状态，封禁过期后自动解除
+func (l *attemptLimiter) isBlocked(chatId int64, userId int64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	key := limiterKey(chatId, userId)
+	until, ok := l.blocked[key]
+	if !ok {
+		return false
+	}
+	if time.Now().After(until) {
+		delete(l.blocked, key)
+		delete(l.fails, key)
+		return false
+	}
+	return true
+}
+
+func limiterKey(chatId int64, userId int64) string {
+	return fmt.Sprintf("%d:%d", chatId, userId)
+}

--- a/src/plugins/gatekeeper/join_request_handle.go
+++ b/src/plugins/gatekeeper/join_request_handle.go
@@ -1,6 +1,7 @@
 package gatekeeper
 
 import (
+	bot "arknights_bot/config"
 	"arknights_bot/utils"
 	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
 )
@@ -9,6 +10,13 @@ func JoinRequestHandle(update tgbotapi.Update) error {
 	var joined utils.GroupJoined
 	utils.GetJoinedByChatId(update.ChatJoinRequest.Chat.ID).Scan(&joined)
 	if joined.RequestMode == 0 { // 不使用此验证
+		return nil
+	}
+	chatId := update.ChatJoinRequest.Chat.ID
+	userId := update.ChatJoinRequest.From.ID
+	if limiter.isBlocked(chatId, userId) {
+		// 多次答题失败被封禁的用户，直接拒绝申请
+		bot.Arknights.DeclineChatJoinRequest(chatId, userId)
 		return nil
 	}
 	go VerifyRequestMember(update)

--- a/src/plugins/gatekeeper/request_callback_handle.go
+++ b/src/plugins/gatekeeper/request_callback_handle.go
@@ -26,8 +26,11 @@ func RequestCallBackData(callBack tgbotapi.Update) error {
 		if d[3] != correct {
 			callbackQuery.Answer(true, "验证未通过")
 			bot.Arknights.DeclineChatJoinRequest(chatId, userId)
+			// 记录失败次数，超过上限后限制该用户再次申请
+			limiter.recordFail(chatId, userId)
 		} else {
 			callbackQuery.Answer(true, "验证通过！")
+			limiter.resetFail(chatId, userId)
 			bot.Arknights.ApproveChatJoinRequest(chatId, userId)
 			// 新人入群提醒
 			var joined utils.GroupJoined


### PR DESCRIPTION
入群验证的 12 个候选答案以内联按钮明文展示，答错仅拒绝且可无限次重新申请，自动化账号（如 MTProto 框架的 spam bot）可反复申请穷举答案，约 12 次申请即可混入。

本 PR 增加失败惩罚：连续答错 3 次后封禁 24 小时，被封禁用户的新入群申请直接拒绝；答对后清零失败记录。