### PR TITLE
feat: log all join-verification decisions

### DIFF
--- a/src/plugins/gatekeeper/request_callback_handle.go
+++ b/src/plugins/gatekeeper/request_callback_handle.go
@@ -6,6 +6,7 @@ import (
 	"arknights_bot/utils"
 	"fmt"
 	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
+	"log"
 	"strconv"
 	"strings"
 )
@@ -26,9 +27,11 @@ func RequestCallBackData(callBack tgbotapi.Update) error {
 		if d[3] != correct {
 			callbackQuery.Answer(true, "验证未通过")
 			bot.Arknights.DeclineChatJoinRequest(chatId, userId)
+			log.Printf("入群验证：拒绝用户 %d（%s）加入群 %d，原因：答错", userId, callbackQuery.From.FullName(), chatId)
 		} else {
 			callbackQuery.Answer(true, "验证通过！")
 			bot.Arknights.ApproveChatJoinRequest(chatId, userId)
+			log.Printf("入群验证：通过用户 %d（%s）加入群 %d，原因：答对", userId, callbackQuery.From.FullName(), chatId)
 			// 新人入群提醒
 			var joined utils.GroupJoined
 			utils.GetJoinedByChatId(chatId).Scan(&joined)

--- a/src/plugins/gatekeeper/request_verify_handle.go
+++ b/src/plugins/gatekeeper/request_verify_handle.go
@@ -14,6 +14,7 @@ import (
 func VerifyRequestMember(update tgbotapi.Update) {
 	chatId := update.ChatJoinRequest.Chat.ID
 	userId := update.ChatJoinRequest.From.ID
+	log.Printf("入群验证：收到用户 %d（%s）的入群申请，群 %d", userId, update.ChatJoinRequest.From.FullName(), chatId)
 	if verifySet.checkExist(userId, chatId) {
 		return
 	}
@@ -76,6 +77,7 @@ func requestVerify(chatId int64, userId int64, messageId int) {
 	if has, _ := verifySet.checkExistAndRemove(userId, chatId); !has {
 		return
 	}
+	log.Printf("入群验证：拒绝用户 %d 加入群 %d，原因：验证超时", userId, chatId)
 	bot.Arknights.DeclineChatJoinRequest(chatId, userId)
 	// 删除入群验证消息
 	delMsg := tgbotapi.NewDeleteMessage(userId, messageId)


### PR DESCRIPTION
入群验证流程此前没有任何决策日志，SPAM 入群后无法判断是答对通过、超时拒绝失败还是其他原因。

本 PR 在以下决策点补充日志：收到申请并开始验证、答对通过、答错拒绝、超时拒绝、发送验证图片失败，方便事后审计。