### PR TITLE
fix: panic protection and boundary guards in join verification

### DIFF
--- a/src/plugins/gatekeeper/request_verify_handle.go
+++ b/src/plugins/gatekeeper/request_verify_handle.go
@@ -8,17 +8,30 @@ import (
 	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
 	"log"
 	"math/big"
+	"runtime/debug"
 	"time"
 )
 
 func VerifyRequestMember(update tgbotapi.Update) {
 	chatId := update.ChatJoinRequest.Chat.ID
 	userId := update.ChatJoinRequest.From.ID
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("入群验证协程异常：%v\n%s", r, debug.Stack())
+			verifySet.checkExistAndRemove(userId, chatId)
+			bot.Arknights.DeclineChatJoinRequest(chatId, userId)
+		}
+	}()
 	if verifySet.checkExist(userId, chatId) {
 		return
 	}
 	// 抽取验证信息
 	operatorsPool := utils.GetOperators()
+	if len(operatorsPool) < 12 { // 不足 12 个干员时去重循环会无限空转，直接放弃本次验证
+		log.Printf("入群验证：干员数据不足，拒绝用户 %d 加入群 %d", userId, chatId)
+		bot.Arknights.DeclineChatJoinRequest(chatId, userId)
+		return
+	}
 	var randNumMap = make(map[int64]struct{})
 	var options []utils.Operator
 	for i := 0; i < 12; i++ { // 随机抽取 12 个干员
@@ -33,6 +46,10 @@ func VerifyRequestMember(update tgbotapi.Update) {
 		}
 		operator := operatorsPool[operatorIndex]
 		operatorName := operator.Name
+		if len(operator.Skins) == 0 {
+			i--
+			continue
+		}
 		painting := operator.Skins[0].Url
 		if painting != "" {
 			options = append(options, utils.Operator{
@@ -44,6 +61,12 @@ func VerifyRequestMember(update tgbotapi.Update) {
 		}
 	}
 
+	if len(options) < 2 {
+		log.Printf("入群验证：可用干员不足，拒绝用户 %d 加入群 %d", userId, chatId)
+		verifySet.checkExistAndRemove(userId, chatId)
+		bot.Arknights.DeclineChatJoinRequest(chatId, userId)
+		return
+	}
 	r, _ := rand.Int(rand.Reader, big.NewInt(int64(len(options)-1)))
 	correct := options[r.Int64()+1]
 	verifySet.add(userId, chatId, correct.Name)

--- a/src/plugins/gatekeeper/verify_handle.go
+++ b/src/plugins/gatekeeper/verify_handle.go
@@ -27,6 +27,11 @@ func VerifyMember(message *tgbotapi.Message) {
 
 	// 抽取验证信息
 	operatorsPool := utils.GetOperators()
+	if len(operatorsPool) < 12 { // 不足 12 个干员时去重循环会无限空转，恢复权限后放弃本次验证
+		log.Println("入群验证：干员数据不足，恢复用户", userId, "发言权限")
+		bot.Arknights.RestrictChatMember(chatId, userId, tgbotapi.AllPermissions)
+		return
+	}
 	var randNumMap = make(map[int64]struct{})
 	var options []utils.Operator
 	for i := 0; i < 12; i++ { // 随机抽取 12 个干员
@@ -41,6 +46,10 @@ func VerifyMember(message *tgbotapi.Message) {
 		}
 		operator := operatorsPool[operatorIndex]
 		operatorName := operator.Name
+		if len(operator.Skins) == 0 {
+			i--
+			continue
+		}
 		painting := operator.Skins[0].Url
 		if painting != "" {
 			options = append(options, utils.Operator{
@@ -52,6 +61,12 @@ func VerifyMember(message *tgbotapi.Message) {
 		}
 	}
 
+	if len(options) < 2 {
+		log.Println("入群验证：可用干员不足，恢复用户", userId, "发言权限")
+		verifySet.checkExistAndRemove(userId, chatId)
+		bot.Arknights.RestrictChatMember(chatId, userId, tgbotapi.AllPermissions)
+		return
+	}
 	r, _ := rand.Int(rand.Reader, big.NewInt(int64(len(options)-1)))
 	correct := options[r.Int64()+1]
 	verifySet.add(userId, chatId, correct.Name)

--- a/src/utils/base_utils.go
+++ b/src/utils/base_utils.go
@@ -334,23 +334,32 @@ func Md5(str string) string {
 	return m5str
 }
 
+var imgClient = &http.Client{Timeout: 15 * time.Second}
+
 func GetImg(url string) []byte {
-	var resp *http.Response
 	var pic []byte
 	times := 0
 	for times < 3 {
-		resp1, err := http.Get(url)
-		resp = resp1
+		resp, err := imgClient.Get(url)
 		if err != nil {
 			log.Println("获取图片失败", err)
 			times++
 			continue
 		}
-		pic, _ = io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			log.Printf("获取图片失败，状态码：%d，URL：%s", resp.StatusCode, url)
+			resp.Body.Close()
+			times++
+			continue
+		}
+		pic, err = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			log.Println("读取图片失败", err)
+			times++
+			continue
+		}
 		break
-	}
-	if resp != nil {
-		defer resp.Body.Close()
 	}
 	return pic
 }


### PR DESCRIPTION
1. VerifyRequestMember 运行在独立 goroutine 且无 recover：operator.Skins[0] 越界或干员数据为空时 rand.Int 返回 nil 后空指针解引用，会直接崩溃整个进程。现增加 recover 保护，异常时记录堆栈并拒绝该入群申请。

2. 抽取验证干员时增加 Skins 空列表防护。

3. 干员池为空或可用选项不足时优雅降级：申请模式拒绝入群，群内模式恢复用户发言权限。

4. GetImg 增加 15 秒超时与 HTTP 状态码检查（原实现使用无超时的默认 client，且不检查状态码，404/500 也会当成功读取）。