### PR TITLE
fix: fail-closed in-group verification, bail on empty images

### DIFF
--- a/src/plugins/gatekeeper/request_verify_handle.go
+++ b/src/plugins/gatekeeper/request_verify_handle.go
@@ -58,7 +58,15 @@ func VerifyRequestMember(update tgbotapi.Update) {
 	inlineKeyboardMarkup := tgbotapi.NewInlineKeyboardMarkup(
 		buttons...,
 	)
-	sendPhoto := tgbotapi.NewPhoto(userId, tgbotapi.FileBytes{Bytes: utils.GetImg(correct.ThumbURL)})
+	img := utils.GetImg(correct.ThumbURL)
+	if len(img) == 0 {
+		// 验证图片获取失败时拒绝入群（fail-closed，绝不放行）
+		log.Printf("入群验证：验证图片获取失败，拒绝用户 %d 加入群 %d。图片：%s", userId, chatId, correct.ThumbURL)
+		verifySet.checkExistAndRemove(userId, chatId)
+		bot.Arknights.DeclineChatJoinRequest(chatId, userId)
+		return
+	}
+	sendPhoto := tgbotapi.NewPhoto(userId, tgbotapi.FileBytes{Bytes: img})
 	sendPhoto.ReplyMarkup = inlineKeyboardMarkup
 	sendPhoto.Caption = "请选择上图干员的正确名字"
 	photo, err := bot.Arknights.Send(sendPhoto)

--- a/src/plugins/gatekeeper/verify_handle.go
+++ b/src/plugins/gatekeeper/verify_handle.go
@@ -78,15 +78,30 @@ func VerifyMember(message *tgbotapi.Message) {
 		verifySet.checkExistAndRemove(userId, chatId)
 		return
 	}
-	sendPhoto := tgbotapi.NewPhoto(chatId, tgbotapi.FileBytes{Bytes: utils.GetImg(correct.ThumbURL)})
+	img := utils.GetImg(correct.ThumbURL)
+	if len(img) == 0 {
+		// 验证图片获取失败视为无法验证，保持 fail-closed 踢出
+		log.Printf("群内验证：验证图片获取失败，踢出用户 %d（%s）。群：%d，图片：%s", userId, name, chatId, correct.ThumbURL)
+		verifySet.checkExistAndRemove(userId, chatId)
+		bot.Arknights.BanChatMember(chatId, userId)
+		delJoinMessage := tgbotapi.NewDeleteMessage(chatId, messageId)
+		bot.Arknights.Send(delJoinMessage)
+		go unban(chatId, userId)
+		return
+	}
+	sendPhoto := tgbotapi.NewPhoto(chatId, tgbotapi.FileBytes{Bytes: img})
 	sendPhoto.ReplyMarkup = inlineKeyboardMarkup
 	sendPhoto.Caption = fmt.Sprintf("欢迎[%s](tg://user?id=%d)，请选择上图干员的正确名字，60秒未选择自动踢出。", tgbotapi.EscapeText(tgbotapi.ModeMarkdownV2, name), userId)
 	sendPhoto.ParseMode = tgbotapi.ModeMarkdownV2
 	photo, err := bot.Arknights.Send(sendPhoto)
 	if err != nil {
-		log.Printf("发送图片失败：%s，原因：%s", correct.ThumbURL, err.Error())
-		bot.Arknights.RestrictChatMember(chatId, userId, tgbotapi.AllPermissions)
+		// 验证信息发送失败时保持限权并踢出，绝不放行未验证用户
+		log.Printf("群内验证：发送验证图片失败，踢出用户 %d（%s）。群：%d，图片：%s，原因：%s", userId, name, chatId, correct.ThumbURL, err.Error())
 		verifySet.checkExistAndRemove(userId, chatId)
+		bot.Arknights.BanChatMember(chatId, userId)
+		delJoinMessage := tgbotapi.NewDeleteMessage(chatId, messageId)
+		bot.Arknights.Send(delJoinMessage)
+		go unban(chatId, userId)
 		return
 	}
 	go verify(chatId, userId, photo.MessageID, messageId)


### PR DESCRIPTION
群内验证模式（非申请模式）中，验证图片发送失败时原代码直接 RestrictChatMember 授予全部权限——未验证用户被直接放行。

本 PR 改为：发送失败或验证图片获取为空时保持 fail-closed，直接踢出（封禁后自动解封，与 60 秒超时路径一致）。申请模式同样增加图片为空预检：图片获取失败时拒绝入群申请，而不是把空字节喂给 Telegram（空字节必然发送失败，触发原 fail-open 路径）。