### PR TITLE
fix: verify all entry paths, restore pre-verify spam guard, clean stale state

### DIFF
--- a/src/core/bot/bot.go
+++ b/src/core/bot/bot.go
@@ -26,6 +26,8 @@ func Serve() {
 	b.JoinRequestProcessor(gatekeeper.JoinRequestHandle)
 	b.NewMemberProcessor(gatekeeper.NewMemberHandle)
 	b.LeftMemberProcessor(gatekeeper.LeftMemberHandle)
+	// 验证期间抢先发送消息的用户直接踢出
+	b.NewProcessor(gatekeeper.CheckMember, gatekeeper.KickMember)
 
 	// callback
 	b.NewCallBackProcessor("verify", gatekeeper.CallBackData)

--- a/src/plugins/gatekeeper/approved_marker.go
+++ b/src/plugins/gatekeeper/approved_marker.go
@@ -1,0 +1,44 @@
+package gatekeeper
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// approvedMarker 记录刚被机器人批准入群的用户，
+// 用于区分「入群申请通过（已答题）」与「链接直入（未答题）」
+type approvedMarker struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+}
+
+var recentlyApproved = approvedMarker{entries: make(map[string]time.Time)}
+
+// approvedMarkerTTL 批准标记的有效时长，超过后视为普通加入
+const approvedMarkerTTL = 10 * time.Minute
+
+func (m *approvedMarker) mark(userId int64, chatId int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries[markerKey(chatId, userId)] = time.Now()
+}
+
+func (m *approvedMarker) is(userId int64, chatId int64) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := markerKey(chatId, userId)
+	t, ok := m.entries[key]
+	if !ok {
+		return false
+	}
+	if time.Since(t) > approvedMarkerTTL {
+		delete(m.entries, key)
+		return false
+	}
+	return true
+}
+
+func markerKey(chatId int64, userId int64) string {
+	return fmt.Sprintf("%d:%d", chatId, userId)
+}

--- a/src/plugins/gatekeeper/check_member.go
+++ b/src/plugins/gatekeeper/check_member.go
@@ -5,6 +5,7 @@ import (
 	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
 )
 
+// CheckMember 匹配验证期间抢先发送消息的用户
 func CheckMember(update tgbotapi.Update) bool {
 	if update.Message != nil && update.Message.Text != "" && verifySet.checkExist(update.SentFrom().ID, update.FromChat().ID) {
 		return true
@@ -12,12 +13,16 @@ func CheckMember(update tgbotapi.Update) bool {
 	return false
 }
 
+// KickMember 踢出验证期间抢发消息的用户；仅对仍处于验证中的用户生效，
+// 避免误伤已通过验证或被管理员手动放行的用户
 func KickMember(update tgbotapi.Update) error {
 	message := update.Message
 	chatId := message.Chat.ID
 	userId := message.From.ID
 	message.Delete()
+	if has, _ := verifySet.checkExistAndRemove(userId, chatId); !has {
+		return nil
+	}
 	bot.Arknights.BanChatMember(chatId, userId)
-	verifyC <- nil
 	return nil
 }

--- a/src/plugins/gatekeeper/left_member_handle.go
+++ b/src/plugins/gatekeeper/left_member_handle.go
@@ -6,5 +6,9 @@ import (
 
 func LeftMemberHandle(update tgbotapi.Update) error {
 	update.Message.Delete()
+	// 清除离开成员的验证状态，避免残留条目影响后续加入
+	if update.Message.LeftChatMember != nil {
+		verifySet.checkExistAndRemove(update.Message.LeftChatMember.ID, update.Message.Chat.ID)
+	}
 	return nil
 }

--- a/src/plugins/gatekeeper/new_member_handle.go
+++ b/src/plugins/gatekeeper/new_member_handle.go
@@ -12,13 +12,33 @@ func NewMemberHandle(update tgbotapi.Update) error {
 	message := update.Message
 	var joined utils.GroupJoined
 	utils.GetJoinedByChatId(message.Chat.ID).Scan(&joined)
-	if joined.RequestMode == 1 { // 不使用此验证
-		return nil
-	}
 	for _, member := range message.NewChatMembers {
 		chatId := message.Chat.ID
 		userId := member.ID
 		if member.ID == message.From.ID { // 自己加入群组
+			// 清除可能残留的验证状态（如申请模式下管理员手动放行遗留的条目）
+			verifySet.checkExistAndRemove(userId, chatId)
+			if joined.RequestMode == 1 && !recentlyApproved.is(userId, chatId) {
+				// 请求模式下未经答题进入（如未开启 Telegram 审核时通过链接加入），仍需验证
+				verifySet.add(userId, chatId, "")
+				chat, err := bot.Arknights.GetChatInfo(member.ID)
+				if err != nil {
+					return err
+				}
+				for _, word := range bot.ADWords {
+					if strings.Contains(chat.Bio, word) {
+						message.Delete()
+						bot.Arknights.BanChatMember(chatId, userId)
+						return nil
+					}
+				}
+				go VerifyMember(message)
+				continue
+			}
+			if joined.RequestMode == 1 {
+				// 请求模式下已由机器人批准（答对验证），无需重复验证
+				continue
+			}
 			verifySet.add(userId, chatId, "")
 			chat, err := bot.Arknights.GetChatInfo(member.ID)
 			if err != nil {
@@ -39,7 +59,8 @@ func NewMemberHandle(update tgbotapi.Update) error {
 			utils.SaveJoined(message)
 			continue
 		}
-		// 邀请加入群组，无需进行验证
+		// 邀请加入群组，无需进行验证（信任管理员邀请）；清除其可能残留的验证状态
+		verifySet.checkExistAndRemove(userId, chatId)
 		utils.SaveInvite(message, &member)
 	}
 	return nil

--- a/src/plugins/gatekeeper/request_callback_handle.go
+++ b/src/plugins/gatekeeper/request_callback_handle.go
@@ -29,6 +29,8 @@ func RequestCallBackData(callBack tgbotapi.Update) error {
 		} else {
 			callbackQuery.Answer(true, "验证通过！")
 			bot.Arknights.ApproveChatJoinRequest(chatId, userId)
+			// 标记为机器人批准进入，避免入群事件触发重复验证
+			recentlyApproved.mark(userId, chatId)
 			// 新人入群提醒
 			var joined utils.GroupJoined
 			utils.GetJoinedByChatId(chatId).Scan(&joined)

--- a/src/plugins/gatekeeper/verify_handle.go
+++ b/src/plugins/gatekeeper/verify_handle.go
@@ -11,8 +11,6 @@ import (
 	"time"
 )
 
-var verifyC = make(chan interface{}, 10)
-
 func VerifyMember(message *tgbotapi.Message) {
 	chatId := message.Chat.ID
 	userId := message.From.ID
@@ -22,6 +20,7 @@ func VerifyMember(message *tgbotapi.Message) {
 	_, err := bot.Arknights.RestrictChatMember(chatId, userId, tgbotapi.NoMessagesPermission)
 	if err != nil {
 		log.Println(err.Error())
+		verifySet.checkExistAndRemove(userId, chatId)
 		return
 	}
 
@@ -70,14 +69,6 @@ func VerifyMember(message *tgbotapi.Message) {
 	inlineKeyboardMarkup := tgbotapi.NewInlineKeyboardMarkup(
 		buttons...,
 	)
-	if len(verifyC) > 0 {
-		obj := <-verifyC
-		log.Println(obj, "停止发送验证信息")
-		message.Delete()
-		bot.Arknights.BanChatMember(chatId, userId)
-		verifySet.checkExistAndRemove(userId, chatId)
-		return
-	}
 	sendPhoto := tgbotapi.NewPhoto(chatId, tgbotapi.FileBytes{Bytes: utils.GetImg(correct.ThumbURL)})
 	sendPhoto.ReplyMarkup = inlineKeyboardMarkup
 	sendPhoto.Caption = fmt.Sprintf("欢迎[%s](tg://user?id=%d)，请选择上图干员的正确名字，60秒未选择自动踢出。", tgbotapi.EscapeText(tgbotapi.ModeMarkdownV2, name), userId)


### PR DESCRIPTION
1）请求模式下 NewMemberHandle 原先直接 return：若群未开启 Telegram 审核，用户经邀请链接可直接进入而完全绕过验证。现改为：链接直入（无批准标记）仍需验证；由机器人批准进入（已答题）跳过重复验证；管理员邀请清除残留状态后免验证。

2）恢复抢跑防护：CheckMember/KickMember 此前从未注册（死代码），现重新注册（b.NewProcessor）；KickMember 仅对仍处于验证中的用户生效（先 checkExistAndRemove 再封禁），避免误伤管理员放行的用户；同时移除失效的 verifyC 熔断逻辑——该逻辑一旦被触发会让后续所有验证者被直接封禁。

3）清理验证状态残留：bio 封禁路径、限权失败路径、成员离开路径均清理 verifySet，避免残留条目导致用户重新加入后收不到题目、申请永久挂起。