### PR TITLE
fix: ad-word filter covers name/username/bio (case-insensitive), fix answer bias

### DIFF
--- a/arknights.example.yaml
+++ b/arknights.example.yaml
@@ -13,6 +13,11 @@ bot:
 sticker:
   ping: CAACAgUAAxkBAAPBZYTpA2TK3cnNG1CfXiLG_9Yo7t8AAiYEAAML4FddSAYCSfeu2jME
 
+# 入群广告词过滤（命中昵称/用户名/简介即拒绝，大小写不敏感）
+ad:
+  - "telegram广告"
+  - "加群送"
+
 api:
   user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Mobile Safari/537.36 EdgA/118.0.2088.66
   wiki: https://prts.wiki/w/

--- a/src/plugins/gatekeeper/ad_filter.go
+++ b/src/plugins/gatekeeper/ad_filter.go
@@ -1,0 +1,24 @@
+package gatekeeper
+
+import (
+	bot "arknights_bot/config"
+	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
+	"strings"
+)
+
+// isAdUser 检查昵称/用户名/简介是否命中广告词（大小写不敏感）
+func isAdUser(member tgbotapi.User, bio string) bool {
+	fields := []string{member.FirstName, member.LastName, member.UserName, bio}
+	for _, word := range bot.ADWords {
+		lowerWord := strings.ToLower(strings.TrimSpace(word))
+		if lowerWord == "" {
+			continue
+		}
+		for _, field := range fields {
+			if strings.Contains(strings.ToLower(field), lowerWord) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/src/plugins/gatekeeper/new_member_handle.go
+++ b/src/plugins/gatekeeper/new_member_handle.go
@@ -5,7 +5,6 @@ import (
 	"arknights_bot/utils"
 	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
 	"github.com/spf13/viper"
-	"strings"
 )
 
 func NewMemberHandle(update tgbotapi.Update) error {
@@ -24,12 +23,10 @@ func NewMemberHandle(update tgbotapi.Update) error {
 			if err != nil {
 				return err
 			}
-			for _, word := range bot.ADWords {
-				if strings.Contains(chat.Bio, word) {
-					message.Delete()
-					bot.Arknights.BanChatMember(chatId, userId)
-					return nil
-				}
+			if isAdUser(member, chat.Bio) {
+				message.Delete()
+				bot.Arknights.BanChatMember(chatId, userId)
+				return nil
 			}
 			go VerifyMember(message)
 			continue

--- a/src/plugins/gatekeeper/request_verify_handle.go
+++ b/src/plugins/gatekeeper/request_verify_handle.go
@@ -14,6 +14,17 @@ import (
 func VerifyRequestMember(update tgbotapi.Update) {
 	chatId := update.ChatJoinRequest.Chat.ID
 	userId := update.ChatJoinRequest.From.ID
+	member := update.ChatJoinRequest.From
+	// 广告词检查：昵称/用户名/简介命中广告词直接拒绝
+	bio := ""
+	if chat, err := bot.Arknights.GetChatInfo(userId); err == nil {
+		bio = chat.Bio
+	}
+	if isAdUser(member, bio) {
+		log.Printf("入群验证：用户 %d（%s）命中广告词，拒绝入群申请。群：%d", userId, member.FullName(), chatId)
+		bot.Arknights.DeclineChatJoinRequest(chatId, userId)
+		return
+	}
 	if verifySet.checkExist(userId, chatId) {
 		return
 	}
@@ -44,8 +55,8 @@ func VerifyRequestMember(update tgbotapi.Update) {
 		}
 	}
 
-	r, _ := rand.Int(rand.Reader, big.NewInt(int64(len(options)-1)))
-	correct := options[r.Int64()+1]
+	r, _ := rand.Int(rand.Reader, big.NewInt(int64(len(options))))
+	correct := options[r.Int64()]
 	verifySet.add(userId, chatId, correct.Name)
 
 	var buttons [][]tgbotapi.InlineKeyboardButton

--- a/src/plugins/gatekeeper/verify_handle.go
+++ b/src/plugins/gatekeeper/verify_handle.go
@@ -52,8 +52,8 @@ func VerifyMember(message *tgbotapi.Message) {
 		}
 	}
 
-	r, _ := rand.Int(rand.Reader, big.NewInt(int64(len(options)-1)))
-	correct := options[r.Int64()+1]
+	r, _ := rand.Int(rand.Reader, big.NewInt(int64(len(options))))
+	correct := options[r.Int64()]
 	verifySet.add(userId, chatId, correct.Name)
 
 	var buttons [][]tgbotapi.InlineKeyboardButton


### PR DESCRIPTION
1）广告词过滤原先只检查 bio、区分大小写，且 example yaml 无默认词表（默认空）。现扩展到昵称/用户名/简介三处、大小写不敏感（isAdUser 辅助函数），并应用到入群申请验证入口 VerifyRequestMember（此前请求模式完全不执行广告词检查）。example yaml 增加示例词表。

2）正确答案抽取 off-by-one 修正：原代码 rand 范围 [0, len-2] 再 +1，导致 options[0] 恒不为答案，12 选 1 退化为 11 选 1。