### PR TITLE
fix: lock operator data loading/reading to prevent mixed-state reads

### DIFF
--- a/src/plugins/datasource/update_data_source.go
+++ b/src/plugins/datasource/update_data_source.go
@@ -233,7 +233,7 @@ func UpdateDataSourceRunner() {
 	utils.RedisSet("operatorList", json.MustMarshalString(operators), 0)
 	MaterialInfo()
 	log.Println("数据源更新完毕")
-	utils.DataNeedUpdate = true
+	utils.SetDataNeedUpdate()
 }
 
 func MaterialInfo() {

--- a/src/utils/arknights_utils.go
+++ b/src/utils/arknights_utils.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/spf13/viper"
 	"github.com/tidwall/gjson"
@@ -70,8 +71,36 @@ var enemyTree suffixtree.GST
 var enemyArray []pair
 var operators []Operator
 
-func GetOperators() []Operator {
+// dataMu 保护干员/敌人/物品数据的并发读写，防止重建期间读取到混合状态
+var dataMu sync.RWMutex
+
+// SetDataNeedUpdate 标记数据需要重新加载（数据源更新完成后调用）
+func SetDataNeedUpdate() {
+	dataMu.Lock()
+	DataNeedUpdate = true
+	dataMu.Unlock()
+}
+
+// ensureData 数据就绪检查，仅在需要重建时获取写锁（double-check）
+func ensureData() {
+	dataMu.RLock()
+	need := DataNeedUpdate
+	dataMu.RUnlock()
+	if !need {
+		return
+	}
+	dataMu.Lock()
+	defer dataMu.Unlock()
+	if !DataNeedUpdate {
+		return
+	}
 	updateData()
+}
+
+func GetOperators() []Operator {
+	ensureData()
+	dataMu.RLock()
+	defer dataMu.RUnlock()
 	return operators
 }
 func updateData() {
@@ -179,8 +208,10 @@ var isTesting = false
 
 func GetOperatorByName(name string) Operator {
 	if !isTesting {
-		updateData()
+		ensureData()
 	}
+	dataMu.RLock()
+	defer dataMu.RUnlock()
 
 	// 先尝试精确匹配
 	lowerName := strings.ToLower(name)
@@ -226,7 +257,9 @@ func GetOperatorByName(name string) Operator {
 }
 
 func GetOperatorsByName(name string) []Operator {
-	updateData()
+	ensureData()
+	dataMu.RLock()
+	defer dataMu.RUnlock()
 	var operatorList []Operator
 	var set = make(map[int]bool)
 
@@ -276,12 +309,16 @@ func GetOperatorsByName(name string) []Operator {
 }
 
 func GetRecruitOperatorList() []Operator {
-	updateData()
+	ensureData()
+	dataMu.RLock()
+	defer dataMu.RUnlock()
 	return recruitOperatorList
 }
 
 func GetEnemiesByName(name string) map[string]string {
-	updateData()
+	ensureData()
+	dataMu.RLock()
+	defer dataMu.RUnlock()
 	var enemyMap = make(map[string]string)
 	for _, index := range enemyTree.Search(strings.ToLower(name)) {
 		a := enemyArray[index]


### PR DESCRIPTION
updateData 在数据源更新后整体重建 operatorMap/operatorTree/operators/enemyArray 等共享结构且无任何锁：多个验证 goroutine 并发调用 GetOperators 时可能读取到混合状态（如新后缀树 + 旧干员列表）导致越界 panic，或重复并发重建。

本 PR 增加 dataMu 读写锁：ensureData 采用 double-check 只在需要重建时获取写锁；所有读取方（GetOperators/GetOperatorByName/GetOperatorsByName/GetRecruitOperatorList/GetEnemiesByName）持读锁；DataNeedUpdate 的外部写入改为 SetDataNeedUpdate()。