### PR TITLE
fix: callback ownership check, atomic registration, index-based callback data

### DIFF
--- a/src/plugins/gatekeeper/request_callback_handle.go
+++ b/src/plugins/gatekeeper/request_callback_handle.go
@@ -22,6 +22,12 @@ func RequestCallBackData(callBack tgbotapi.Update) error {
 	userId, _ := strconv.ParseInt(d[1], 10, 64)
 	chatId, _ := strconv.ParseInt(d[2], 10, 64)
 
+	// 校验回调发起者必须是申请人本人
+	if callbackQuery.From.ID != userId {
+		callbackQuery.Answer(true, "这不是你的验证！")
+		return nil
+	}
+
 	if has, correct := verifySet.checkExistAndRemove(userId, chatId); has {
 		if d[3] != correct {
 			callbackQuery.Answer(true, "验证未通过")

--- a/src/plugins/gatekeeper/request_verify_handle.go
+++ b/src/plugins/gatekeeper/request_verify_handle.go
@@ -8,6 +8,7 @@ import (
 	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
 	"log"
 	"math/big"
+	"strconv"
 	"time"
 )
 
@@ -45,14 +46,19 @@ func VerifyRequestMember(update tgbotapi.Update) {
 	}
 
 	r, _ := rand.Int(rand.Reader, big.NewInt(int64(len(options)-1)))
-	correct := options[r.Int64()+1]
-	verifySet.add(userId, chatId, correct.Name)
+	correctIdx := r.Int64() + 1
+	correct := options[correctIdx]
+	// 原子登记验证条目（防止重投更新产生重复题目），callback 携带选项序号而非干员名，
+	// 既规避 Telegram 64 字节回调数据上限，也避免答案明文出现在客户端可见数据中
+	if !verifySet.addIfNotExist(userId, chatId, strconv.FormatInt(correctIdx, 10)) {
+		return
+	}
 
 	var buttons [][]tgbotapi.InlineKeyboardButton
 	for i := 0; i < len(options); i += 2 {
 		buttons = append(buttons, tgbotapi.NewInlineKeyboardRow(
-			tgbotapi.NewInlineKeyboardButtonData(options[i].Name, fmt.Sprintf("request,%d,%d,%s", userId, chatId, options[i].Name)),
-			tgbotapi.NewInlineKeyboardButtonData(options[i+1].Name, fmt.Sprintf("request,%d,%d,%s", userId, chatId, options[i+1].Name)),
+			tgbotapi.NewInlineKeyboardButtonData(options[i].Name, fmt.Sprintf("request,%d,%d,%d", userId, chatId, i)),
+			tgbotapi.NewInlineKeyboardButtonData(options[i+1].Name, fmt.Sprintf("request,%d,%d,%d", userId, chatId, i+1)),
 		))
 	}
 	inlineKeyboardMarkup := tgbotapi.NewInlineKeyboardMarkup(

--- a/src/plugins/gatekeeper/safe_verify_set.go
+++ b/src/plugins/gatekeeper/safe_verify_set.go
@@ -33,6 +33,20 @@ func (b *safeCallBack) checkExist(userId useridT, chatId chatidT) bool {
 	return false
 }
 
+// addIfNotExist 原子地检查并登记验证条目，已存在时返回 false，
+// 避免 checkExist 与 add 之间的 TOCTOU 窗口导致重复下发题目
+func (b *safeCallBack) addIfNotExist(userId useridT, chatId chatidT, correct string) bool {
+	defer b.mu.Unlock()
+	b.mu.Lock()
+	val := fmt.Sprintf("%d%d", chatId, userId)
+	if b._checkVal(val) {
+		return false
+	}
+	b.set[val] = true
+	b.correct = correct
+	return true
+}
+
 func (b *safeCallBack) checkExistAndRemove(userId useridT, chatId chatidT) (bool, string) {
 	defer b.mu.Unlock()
 	b.mu.Lock()


### PR DESCRIPTION
1）申请模式回调未校验 callbackQuery.From.ID == userId（群内模式 callback_handle.go 有此校验），现补齐。

2）checkExist 与 add 之间的 TOCTOU 窗口改为原子方法 addIfNotExist，避免 Telegram 重投更新时重复下发题目。

3）回调数据由明文干员名改为选项序号（request,userId,chatId,序号），彻底规避 Telegram 64 字节回调数据上限（历史提交 5d5b3ec 曾因数据超长把前缀从 request_verify 缩短为 request），也避免答案明文出现在客户端可见数据中。