### PR TITLE
feat: persist pending join verifications, recover timers on restart

### DIFF
--- a/arknights.sql
+++ b/arknights.sql
@@ -41,9 +41,24 @@ CREATE TABLE `group_joined`  (
 -- ----------------------------
 -- Table structure for group_lottery
 -- ----------------------------
+-- ----------------------------
+-- Table structure for join_request_verify
+-- ----------------------------
+DROP TABLE IF EXISTS `join_request_verify`;
+CREATE TABLE `join_request_verify`  (
+  `chat_id` bigint NOT NULL COMMENT '群组ID',
+  `user_id` bigint NOT NULL COMMENT '用户ID',
+  `correct` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT '' COMMENT '验证答案',
+  `message_id` int NOT NULL DEFAULT 0 COMMENT '验证图片消息ID',
+  `expire_at` datetime NOT NULL COMMENT '验证过期时间',
+  PRIMARY KEY (`chat_id`, `user_id`) USING BTREE
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci COMMENT = '入群验证待处理状态' ROW_FORMAT = Dynamic;
+
+-- ----------------------------
+-- Table structure for group_lottery
+-- ----------------------------
 DROP TABLE IF EXISTS `group_lottery`;
-CREATE TABLE `group_lottery`  (
-  `id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+CREATE TABLE `group_lottery`  (  `id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
   `group_name` varchar(150) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '群组名称',
   `group_number` bigint NULL DEFAULT NULL COMMENT '群组ID',
   `status` int NULL DEFAULT 1 COMMENT '抽奖状态0关闭1开启2暂停报名',

--- a/src/core/bot/bot.go
+++ b/src/core/bot/bot.go
@@ -20,6 +20,8 @@ import (
 // Serve TG机器人阻塞监听
 func Serve() {
 	log.Println("机器人启动成功")
+	// 恢复重启前挂起的入群验证（过期拒绝，未过期重启定时器）
+	gatekeeper.RecoverPendingVerifications()
 	b := bot.Arknights.AddHandle()
 	bot.Arknights.Debug = viper.GetBool("bot.debug")
 	bot.Arknights.IgnoreChannelCMD = true

--- a/src/plugins/gatekeeper/request_callback_handle.go
+++ b/src/plugins/gatekeeper/request_callback_handle.go
@@ -23,6 +23,7 @@ func RequestCallBackData(callBack tgbotapi.Update) error {
 	chatId, _ := strconv.ParseInt(d[2], 10, 64)
 
 	if has, correct := verifySet.checkExistAndRemove(userId, chatId); has {
+		verifyRemove(chatId, userId)
 		if d[3] != correct {
 			callbackQuery.Answer(true, "验证未通过")
 			bot.Arknights.DeclineChatJoinRequest(chatId, userId)

--- a/src/plugins/gatekeeper/request_verify_handle.go
+++ b/src/plugins/gatekeeper/request_verify_handle.go
@@ -47,6 +47,8 @@ func VerifyRequestMember(update tgbotapi.Update) {
 	r, _ := rand.Int(rand.Reader, big.NewInt(int64(len(options)-1)))
 	correct := options[r.Int64()+1]
 	verifySet.add(userId, chatId, correct.Name)
+	// 持久化待验证状态，重启后可恢复定时器
+	verifySave(chatId, userId, correct.Name)
 
 	var buttons [][]tgbotapi.InlineKeyboardButton
 	for i := 0; i < len(options); i += 2 {
@@ -66,8 +68,11 @@ func VerifyRequestMember(update tgbotapi.Update) {
 		log.Printf("发送图片失败：%s，原因：%s", correct.ThumbURL, err.Error())
 		bot.Arknights.ApproveChatJoinRequest(chatId, userId)
 		verifySet.checkExistAndRemove(userId, chatId)
+		verifyRemove(chatId, userId)
 		return
 	}
+	// 记录验证图片消息 ID，供超时后删除
+	verifySaveMessage(chatId, userId, photo.MessageID)
 	go requestVerify(chatId, userId, photo.MessageID)
 }
 
@@ -76,8 +81,11 @@ func requestVerify(chatId int64, userId int64, messageId int) {
 	if has, _ := verifySet.checkExistAndRemove(userId, chatId); !has {
 		return
 	}
+	verifyRemove(chatId, userId)
 	bot.Arknights.DeclineChatJoinRequest(chatId, userId)
 	// 删除入群验证消息
-	delMsg := tgbotapi.NewDeleteMessage(userId, messageId)
-	bot.Arknights.Send(delMsg)
+	if messageId > 0 {
+		delMsg := tgbotapi.NewDeleteMessage(userId, messageId)
+		bot.Arknights.Send(delMsg)
+	}
 }

--- a/src/plugins/gatekeeper/verify_store.go
+++ b/src/plugins/gatekeeper/verify_store.go
@@ -1,0 +1,78 @@
+package gatekeeper
+
+import (
+	bot "arknights_bot/config"
+	"log"
+	"time"
+)
+
+// verifyStore 待验证入群申请状态的持久化。
+// 验证状态原先仅存内存，机器人重启后挂起的入群申请无人处理，用户永久卡死；
+// 持久化后可在启动时恢复定时器，过期申请统一拒绝。
+
+const verifyTable = "join_request_verify"
+
+type joinRequestVerify struct {
+	ChatID    int64     `gorm:"column:chat_id;primaryKey"`
+	UserID    int64     `gorm:"column:user_id;primaryKey"`
+	Correct   string    `gorm:"column:correct"`
+	MessageID int       `gorm:"column:message_id"`
+	ExpireAt  time.Time `gorm:"column:expire_at"`
+}
+
+// verifyExpireSlack 持久化条目的过期余量：add 先于发送图片，实际超时为 60 秒，
+// 此处留出发送与网络余量
+const verifyExpireSlack = 90 * time.Second
+
+func ensureVerifyTable() {
+	err := bot.DBEngine.Exec("CREATE TABLE IF NOT EXISTS `join_request_verify` (`chat_id` bigint NOT NULL, `user_id` bigint NOT NULL, `correct` varchar(64) NOT NULL DEFAULT '', `message_id` int NOT NULL DEFAULT 0, `expire_at` datetime NOT NULL, PRIMARY KEY (`chat_id`,`user_id`)) ENGINE = InnoDB CHARACTER SET = utf8mb4 COMMENT = '入群验证待处理状态'").Error
+	if err != nil {
+		log.Printf("入群验证：创建持久化表失败：%v", err)
+	}
+}
+
+// verifySave 持久化待验证状态（存在则刷新）
+func verifySave(chatId int64, userId int64, correct string) {
+	err := bot.DBEngine.Exec("INSERT INTO `join_request_verify` (`chat_id`, `user_id`, `correct`, `message_id`, `expire_at`) VALUES (?, ?, ?, 0, ?) ON DUPLICATE KEY UPDATE `correct` = VALUES(`correct`), `expire_at` = VALUES(`expire_at`)", chatId, userId, correct, time.Now().Add(verifyExpireSlack)).Error
+	if err != nil {
+		log.Printf("入群验证：持久化验证状态失败：%v", err)
+	}
+}
+
+// verifySaveMessage 记录验证图片消息 ID，供超时后删除
+func verifySaveMessage(chatId int64, userId int64, messageId int) {
+	err := bot.DBEngine.Exec("UPDATE `join_request_verify` SET `message_id` = ? WHERE `chat_id` = ? AND `user_id` = ?", messageId, chatId, userId).Error
+	if err != nil {
+		log.Printf("入群验证：更新验证消息 ID 失败：%v", err)
+	}
+}
+
+// verifyRemove 清理持久化状态
+func verifyRemove(chatId int64, userId int64) {
+	err := bot.DBEngine.Exec("DELETE FROM `join_request_verify` WHERE `chat_id` = ? AND `user_id` = ?", chatId, userId).Error
+	if err != nil {
+		log.Printf("入群验证：清理持久化状态失败：%v", err)
+	}
+}
+
+// RecoverPendingVerifications 启动时恢复挂起的入群验证：
+// 已过期的拒绝入群申请，未过期的重建内存状态并重启 60 秒超时定时器
+func RecoverPendingVerifications() {
+	ensureVerifyTable()
+	var rows []joinRequestVerify
+	if err := bot.DBEngine.Table(verifyTable).Find(&rows).Error; err != nil {
+		log.Printf("入群验证：读取待恢复验证状态失败：%v", err)
+		return
+	}
+	now := time.Now()
+	for _, row := range rows {
+		if row.ExpireAt.Before(now) {
+			log.Printf("入群验证：恢复时发现过期验证，拒绝用户 %d 加入群 %d", row.UserID, row.ChatID)
+			bot.Arknights.DeclineChatJoinRequest(row.ChatID, row.UserID)
+			verifyRemove(row.ChatID, row.UserID)
+			continue
+		}
+		verifySet.add(row.UserID, row.ChatID, row.Correct)
+		go requestVerify(row.ChatID, row.UserID, row.MessageID)
+	}
+}


### PR DESCRIPTION
入群验证状态此前仅存内存 + time.Sleep 定时器：机器人重启后挂起的申请无人处理、验证图片无法删除，用户永久卡死（Telegram Bot API 无法枚举挂起申请，只能靠本地状态恢复）。

本 PR 将待验证状态持久化到新表 join_request_verify（启动时自动 CREATE TABLE IF NOT EXISTS，无需手动迁移）：下发题目时写入、作答/超时/失败路径清理；启动时恢复——已过期的直接拒绝入群申请，未过期的重建内存状态并重启 60 秒超时定时器（含验证图片删除）。arknights.sql 同步新增表定义。